### PR TITLE
fix spring cloud config variable names

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaSpring/libraries/spring-cloud/clientConfiguration.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/libraries/spring-cloud/clientConfiguration.mustache
@@ -24,10 +24,10 @@ public class ClientConfiguration {
 
 {{#authMethods}}
     {{#isBasic}}
-  @Value("${ {{{title}}}.security.{{{name}}}.username:}")
+  {{=<% %>=}}@Value("${<%title%>.security.<%name%>.username:}")<%={{ }}=%>
   private String {{{name}}}Username;
 
-  @Value("${ {{{title}}}.security.{{{name}}}.password:}")
+  {{=<% %>=}}@Value("${<%title%>.security.<%name%>.password:}")<%={{ }}=%>
   private String {{{name}}}Password;
 
   @Bean
@@ -38,7 +38,7 @@ public class ClientConfiguration {
 
     {{/isBasic}}
     {{#isApiKey}}
-  @Value("${ {{{title}}}.security.{{{name}}}.key:}")
+  {{=<% %>=}}@Value("${<%title%>.security.<%name%>.key:}")<%={{ }}=%>
   private String {{{name}}}Key;
 
   @Bean


### PR DESCRIPTION
remove leading space

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [no need] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [Master] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09)

### Description of the PR

fix the config variable names in order to remove the leading space that makes the cinfig unusable (at least in properties.yml) it's done the same way in API Client
